### PR TITLE
Winsa/add purchases int

### DIFF
--- a/models/gold/core/_core.yml
+++ b/models/gold/core/_core.yml
@@ -103,6 +103,15 @@ models:
       - name: has_subscription
         description: Whether the device has an active subscription. Not sure this is really what it is.
         data_type: boolean
+      - name: total_usd_spent
+        description: Total amount spent in USD by the device
+        data_type: float
+      - name: total_products
+        description: Total number of products purchased by the device
+        data_type: integer
+      - name: has_purchased
+        description: Whether the device has made any purchases
+        data_type: boolean
 
   - name: fct_purchases
     description: one row per in-app purchase event, with price converted to USD

--- a/models/gold/core/dim_device.sql
+++ b/models/gold/core/dim_device.sql
@@ -1,18 +1,32 @@
 with events as (select * from {{ ref("stg_events") }}),
 
-final as (
-    select
+    int_purchases as (
+        select
+            device_id,
+            sum(price_usd) as total_usd_spent,
+            sum(quantity) as total_products,
+            true as has_purchased
+        from {{ref("int_purchases")}}
+        group by all
+    ),
+
+    final as (
+        select
         /* there are probably cleaner ways of doing this, e.g. mapping early events install_id to later
         events install_id where device_id is populated */
-        coalesce(device_id, install_id) as device_id,
-        max_by(device_category, event_timestamp) as device_category,
-        max_by(install_source, event_timestamp) as install_source,
-        from_utc_timestamp(min(event_timestamp), 'Europe/Stockholm') as first_event_at_local,
-        from_utc_timestamp(max(event_timestamp), 'Europe/Stockholm') as last_event_at_local,
-        max(ga_session_number) as number_of_sessions,
-        coalesce(max(subscription), false) as has_subscription
-    from events
-    group by all
-)
+            coalesce(device_id, install_id) as device_id,
+            max_by(device_category, event_timestamp) as device_category,
+            max_by(install_source, event_timestamp) as install_source,
+            from_utc_timestamp(min(event_timestamp), 'Europe/Stockholm') as first_event_at_local,
+            from_utc_timestamp(max(event_timestamp), 'Europe/Stockholm') as last_event_at_local,
+            max(ga_session_number) as number_of_sessions,
+            coalesce(max(subscription), false) as has_subscription,
+            coalesce(sum(total_usd_spent), 0) as total_usd_spent,
+            coalesce(sum(total_products), 0) as total_products,
+            coalesce(has_purchased, false) as has_purchased
+        from events
+        left join int_purchases using (device_id)
+        group by all
+    )
 
 select * from final

--- a/models/gold/core/fct_purchases.sql
+++ b/models/gold/core/fct_purchases.sql
@@ -1,21 +1,13 @@
-with events as (select * from {{ ref("stg_events") }}),
+with int_purchases as (select * from {{ ref("int_purchases") }}),
 
-exchange_rates as (
-    select * from {{ ref("stg_exchange_rates") }}
-),
-
-final as (
-select
-    from_utc_timestamp(event_timestamp, 'Europe/Stockholm') as purchased_at_local,
-    coalesce(device_id, install_id) as device_id,
-    price * usd_per_currency as price_usd,
-    lower(product_name) as product_name,
-    --quantity seems to always be 1, so assuming it may never bundle items even of the same kind, I would fix this in a prod model
-    quantity
-from events
-left join exchange_rates on events.currency_code = exchange_rates.currency_code
-    and events.event_date = exchange_rates.date
-where event_name = 'in_app_purchase'
-)
+    final as (
+        select
+            purchased_at_local,
+            device_id,
+            price_usd,
+            product_name,
+            quantity
+        from int_purchases
+    )
 
 select * from final

--- a/models/gold/core/intermediate/_intermediate.yml
+++ b/models/gold/core/intermediate/_intermediate.yml
@@ -1,0 +1,18 @@
+models:
+  - name: int_purchases
+    description: >
+      ephemeral (not materialised) model splitting out logic for in app purchases on purchase level.
+      Built as int model so these metrics can be used in multiple downstream models.
+    columns:
+      - name: purchased_at_local
+        description: Timestamp in CET/CEST Stockholm local time when the purchase occurred
+        data_type: datetime
+      - name: device_id
+        description: Unique identifier for device, can be null for some earlier events where its coalesced with install_id.
+        data_type: string
+      - name: price_usd
+        description: Price of the purchased item, converted to USD using the exchange rate on the day of the purchase.
+        data_type: float
+      - name: product_name
+        description: Name of the purchased product, lowercased.
+        data_type: string

--- a/models/gold/core/intermediate/int_purchases.sql
+++ b/models/gold/core/intermediate/int_purchases.sql
@@ -1,0 +1,24 @@
+{{config(
+    materialized='ephemeral'
+)}}
+
+with events as (select * from {{ ref("stg_events") }}where event_name = 'in_app_purchase'),
+
+exchange_rates as (
+    select * from {{ ref("stg_exchange_rates") }}
+),
+
+final as (
+select
+    from_utc_timestamp(event_timestamp, 'Europe/Stockholm') as purchased_at_local,
+    coalesce(device_id, install_id) as device_id,
+    price * usd_per_currency as price_usd,
+    lower(product_name) as product_name,
+    --quantity seems to always be 1, so assuming it may never bundle items even of the same kind, I would fix this in a prod model
+    quantity
+from events
+left join exchange_rates on events.currency_code = exchange_rates.currency_code
+    and events.event_date = exchange_rates.date
+)
+
+select * from final


### PR DESCRIPTION
Splits out purchasing logic to an intermediate model, so it can then be re-used in multiple models doswnstream. In this case in fct_purchases, and dim_device, aggregated to device level. Ensures its re-usable and keeps one source of truth. 